### PR TITLE
Feature/unittests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.10, 3.13]
+        python-version: ['3.10', '3.13']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,28 @@
+name: Python Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.10, 3.13]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+        poetry install
+
+    - name: Run tests
+      run: poetry run pytest

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.10', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v3

--- a/main.py
+++ b/main.py
@@ -87,7 +87,12 @@ class MarkdownPDFConverter:
             raise
 
         try:
-            template = jinja2.Template(template_content)
+            # Configure the Jinja2 environment to raise an exception on undefined variables
+            env = jinja2.Environment(
+                loader=jinja2.BaseLoader(),
+                undefined=jinja2.StrictUndefined
+            )
+            template = env.from_string(template_content)
             self.logger.debug(f'Applying template from: {template_path}')
             return template.render(content=html_content)
         except jinja2.TemplateSyntaxError as e:

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,6 +37,8 @@ mypy-extensions = ">=0.4.3"
 packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -339,6 +341,20 @@ webencodings = "*"
 [package.extras]
 doc = ["sphinx", "sphinx_rtd_theme"]
 test = ["flake8", "isort", "pytest"]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "flake8"
@@ -823,9 +839,11 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -865,6 +883,28 @@ webencodings = ">=0.5.1"
 [package.extras]
 doc = ["sphinx", "sphinx_rtd_theme"]
 test = ["pytest", "ruff"]
+
+[[package]]
+name = "tomli"
+version = "2.1.0"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tomli-2.1.0-py3-none-any.whl", hash = "sha256:a5c57c3d1c56f5ccdf89f6523458f60ef716e210fc47c4cfb188c5ba473e0391"},
+    {file = "tomli-2.1.0.tar.gz", hash = "sha256:3f646cae2aec94e17d04973e4249548320197cfabdf130015d023de4b74d8ab8"},
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+description = "Backported and Experimental Type Hints for Python 3.8+"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+]
 
 [[package]]
 name = "weasyprint"
@@ -987,5 +1027,5 @@ test = ["pytest"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.13"
-content-hash = "0f3828f9f0ed0d58a37c01d18ee2164a16ec458054f293128595bf980a084535"
+python-versions = "^3.10"
+content-hash = "da407c4ae93a69573d1338c873e4cfd0e1fd27078a443ae7987e8dad4c73fc22"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["markdown", "pdf", "converter", "templates"]
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.13"
+python = "^3.10"
 markdown = "^3.4"
 jinja2 = "^3.1"
 weasyprint = "^63.0"

--- a/test_main.py
+++ b/test_main.py
@@ -47,7 +47,7 @@ def test_invalid_template(tmp_path):
     invalid_template = "<html><body>{{ undefined_variable }}</body></html>"
     template_path = tmp_path / "template.html"
     template_path.write_text(invalid_template)
-    with pytest.raises(jinja2.UndefinedError):
+    with pytest.raises(jinja2.exceptions.UndefinedError):
         converter.render_template(html_content, str(template_path))
 
 def test_output_directory_permissions(tmp_path):

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,62 @@
+# test_main.py
+
+import os
+import pytest
+import jinja2
+from main import MarkdownPDFConverter
+
+def test_markdown_to_html():
+    converter = MarkdownPDFConverter()
+    md_content = "# Hello World\nThis is a test."
+    html_content = converter.markdown_to_html(md_content)
+    assert "<h1>Hello World</h1>" in html_content
+
+def test_render_template(tmp_path):
+    converter = MarkdownPDFConverter()
+    html_content = "<p>This is content</p>"
+    template_content = "<html><body>{{ content }}</body></html>"
+    template_path = tmp_path / "template.html"
+    template_path.write_text(template_content)
+    rendered_html = converter.render_template(html_content, str(template_path))
+    assert "<body><p>This is content</p></body>" in rendered_html
+
+def test_html_to_pdf(tmp_path):
+    converter = MarkdownPDFConverter()
+    html_content = "<h1>PDF Test</h1><p>Testing PDF generation.</p>"
+    output_pdf_path = tmp_path / "output.pdf"
+    converter.html_to_pdf(html_content, str(output_pdf_path))
+    assert output_pdf_path.exists()
+
+def test_process_files(tmp_path):
+    converter = MarkdownPDFConverter()
+    md_content = "# Test Markdown\nContent for testing."
+    input_md_path = tmp_path / "input.md"
+    input_md_path.write_text(md_content)
+    output_pdf_path = tmp_path / "output.pdf"
+    converter.process_files(str(input_md_path), str(output_pdf_path), force_overwrite=True)
+    assert output_pdf_path.exists()
+
+def test_missing_input_file():
+    converter = MarkdownPDFConverter()
+    with pytest.raises(FileNotFoundError):
+        converter.read_file("nonexistent.md")
+
+def test_invalid_template(tmp_path):
+    converter = MarkdownPDFConverter()
+    html_content = "<p>Test Content</p>"
+    invalid_template = "<html><body>{{ undefined_variable }}</body></html>"
+    template_path = tmp_path / "template.html"
+    template_path.write_text(invalid_template)
+    with pytest.raises(jinja2.UndefinedError):
+        converter.render_template(html_content, str(template_path))
+
+def test_output_directory_permissions(tmp_path):
+    converter = MarkdownPDFConverter()
+    md_content = "# Test"
+    input_md_path = tmp_path / "input.md"
+    input_md_path.write_text(md_content)
+    output_dir = tmp_path / "no_write_permission"
+    output_dir.mkdir(mode=0o400)
+    output_pdf_path = output_dir / "output.pdf"
+    with pytest.raises(SystemExit):
+        converter.process_files(str(input_md_path), str(output_pdf_path))


### PR DESCRIPTION
This pull request includes several important changes to the project, including adding a new GitHub Actions workflow for running Python tests, updating the Jinja2 environment configuration, modifying the Python version in `pyproject.toml`, and adding new tests for the `MarkdownPDFConverter` class.

### New GitHub Actions Workflow:
* Added a new GitHub Actions workflow to run Python tests on push and pull request events, supporting multiple Python versions (3.10 to 3.13). (`.github/workflows/python-tests.yml`)

### Jinja2 Environment Configuration:
* Updated the `render_template` method to configure the Jinja2 environment to raise an exception on undefined variables, enhancing error handling. (`main.py`)

### Dependency Updates:
* Changed the Python version requirement in `pyproject.toml` from `^3.13` to `^3.10` to support a broader range of Python versions. (`pyproject.toml`)

### New Tests:
* Added comprehensive tests for the `MarkdownPDFConverter` class, covering methods such as `markdown_to_html`, `render_template`, `html_to_pdf`, `process_files`, and error handling scenarios. (`test_main.py`)